### PR TITLE
[REFAC] 조회수 최적화 기능 구현

### DIFF
--- a/src/main/java/com/forwork/backend/api/recruit_review/controller/RecruitReviewController.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/controller/RecruitReviewController.java
@@ -7,7 +7,7 @@ import com.forwork.backend.api.recruit_review.dto.request.RecruitReviewUpdateDTO
 import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewDetailResponseDTO;
 import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewParentCommentResponseDTO;
 import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewPreviewResponseDTO;
-import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewToTalCountResponseDTO;
+import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewTotalCountResponseDTO;
 import com.forwork.backend.api.recruit_review.enums.RecruitReviewSortType;
 import com.forwork.backend.api.recruit_review.service.RecruitReviewCommentService;
 import com.forwork.backend.api.recruit_review.service.RecruitReviewService;
@@ -111,15 +111,15 @@ public class RecruitReviewController {
 
     @Operation(
             summary = "후기 totalCount 조회  API (용범)",
-            description = "출력: RecruitReviewDetailResponseDTO"
+            description = "출력: RecruitReviewTotalCountResponseDTO"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "후기 총 개수 조회 성공"),
     })
     @GetMapping("/total-count")
-    public ResponseEntity<ApiResponse<RecruitReviewToTalCountResponseDTO>> getRecruit() {
+    public ResponseEntity<ApiResponse<RecruitReviewTotalCountResponseDTO>> getRecruit() {
 
-        RecruitReviewToTalCountResponseDTO response = recruitReviewService.getRecruitReviewTotalCount();
+        RecruitReviewTotalCountResponseDTO response = recruitReviewService.getRecruitReviewTotalCount();
 
         return ApiResponse.success(SuccessStatus.RECRUIT_REVIEW_TOTAL_COUNT_SUCCESS, response);
     }

--- a/src/main/java/com/forwork/backend/api/recruit_review/dto/response/RecruitReviewDetailResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/dto/response/RecruitReviewDetailResponseDTO.java
@@ -32,13 +32,13 @@ public record RecruitReviewDetailResponseDTO(
         JobCategory jobCategory
 ) {
 
-        public static RecruitReviewDetailResponseDTO of(RecruitReview review, Long commentCount, boolean isMine, Member writer) {
+        public static RecruitReviewDetailResponseDTO of(RecruitReview review, Long commentCount, boolean isMine, Member writer, int readCount) {
                 return new RecruitReviewDetailResponseDTO(
                         review.getId(),
                         review.getRegion1(),
                         review.getRegion2(),
                         review.getTitle(),
-                        review.getReadCount()+1,
+                        (readCount==-1)?review.getReadCount()+1:readCount,
                         commentCount,
                         review.getContent(),
                         writer.getUserId(),

--- a/src/main/java/com/forwork/backend/api/recruit_review/dto/response/RecruitReviewPreviewResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/dto/response/RecruitReviewPreviewResponseDTO.java
@@ -28,6 +28,20 @@ public record RecruitReviewPreviewResponseDTO(
         long commentCount
 
 ) {
+        public static RecruitReviewPreviewResponseDTO of(RecruitReviewPreviewInternalDTO dto, int readCount){
+                return new RecruitReviewPreviewResponseDTO(
+                        dto.recruitReviewId(),
+                        dto.jobCategory(),
+                        dto.title(),
+                        dto.content(),
+                        dto.region1(),
+                        dto.region2(),
+                        dto.createAt(),
+                        (readCount==-1)?dto.readCount():readCount,
+                        dto.commentCount()
+                );
+        }
+
         public static RecruitReviewPreviewResponseDTO of(RecruitReviewPreviewInternalDTO dto){
                 return new RecruitReviewPreviewResponseDTO(
                         dto.recruitReviewId(),

--- a/src/main/java/com/forwork/backend/api/recruit_review/dto/response/RecruitReviewTotalCountResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/dto/response/RecruitReviewTotalCountResponseDTO.java
@@ -2,7 +2,7 @@ package com.forwork.backend.api.recruit_review.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record RecruitReviewToTalCountResponseDTO (
+public record RecruitReviewTotalCountResponseDTO(
         @Schema(description = "후기 totalCount")
         Long totalCount
 ){

--- a/src/main/java/com/forwork/backend/api/recruit_review/repository/RecruitReviewCommentRepository.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/repository/RecruitReviewCommentRepository.java
@@ -12,8 +12,9 @@ import java.util.Optional;
 public interface RecruitReviewCommentRepository extends JpaRepository<RecruitReviewComment, Long> {
 
     @Query("select c from RecruitReviewComment c" +
-            " where c.id=:id and c.parent is null")
-    Optional<RecruitReviewComment> findParentCommentIfRoot(@Param("id") Long id);
+            " left join fetch c.parent" +
+            " where c.id=:id and c.isDeleted=false")
+    Optional<RecruitReviewComment> findByIdWithParent(@Param("id") Long id);
 
     @Query("select c from RecruitReviewComment c" +
             " left join fetch c.writer" +

--- a/src/main/java/com/forwork/backend/api/recruit_review/repository/RecruitReviewRepository.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/repository/RecruitReviewRepository.java
@@ -26,4 +26,10 @@ public interface RecruitReviewRepository extends JpaRepository<RecruitReview, Lo
     @Transactional
     @Query("update RecruitReview r set r.readCount=r.readCount+1 where r.id=:recruitReviewId")
     void incrementReadCount(@Param("recruitReviewId")Long recruitReviewId);
+
+
+    @Modifying
+    @Transactional
+    @Query("update RecruitReview r set r.readCount=:newReadCount where r.id=:recruitReviewId")
+    void updateViewCount(@Param("recruitReviewId")Long recruitReviewId, @Param("newReadCount")Integer newReadCount);
 }

--- a/src/main/java/com/forwork/backend/api/recruit_review/service/FlushScheduler.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/service/FlushScheduler.java
@@ -1,0 +1,21 @@
+package com.forwork.backend.api.recruit_review.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+//@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FlushScheduler {
+    private final ReadCountFlusher flusher;
+
+
+    @Scheduled(fixedDelay = 3000) // ms
+    public void scheduledFlush() {
+        log.info("[ReadCountFlusher][begin]");
+        flusher.flush();
+        log.info("[ReadCountFlusher][end]");
+    }
+}

--- a/src/main/java/com/forwork/backend/api/recruit_review/service/ReadCountFlusher.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/service/ReadCountFlusher.java
@@ -1,0 +1,71 @@
+package com.forwork.backend.api.recruit_review.service;
+
+import com.forwork.backend.api.recruit_review.repository.RecruitReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+//@Component
+@RequiredArgsConstructor
+public class ReadCountFlusher {
+    private final ReadCountTracker tracker;
+    private final RecruitReviewRepository recruitReviewRepository;
+    private final int THRESHOLD = 10;                                               // 인기없는 글 판단을 위한 THRESHOLD 값.    flush 주기 동안 THRESHOLD 이상인 게시글만 tracker 에 유지한다.
+    private static final Duration POPULARITY_GRACE_PERIOD = Duration.ofMinutes(10); // 게시글이 '인기글'로 분류될 유예 기간
+
+    /**
+     * tracker 에서 조회수들을 갖고 와 DB에 반영한다.
+     *
+     * 메모리 효율을 위해 조회수 변화량이 적은 글은 tacker 에서 제거.
+     *
+     * 조회수 변화량이 적은 글: 게시글이 생성된지 POPULARITY_GRACE_PERIOD 이상이지만 조회수 변화량이 THRESHOLD 이하인 글로 정의.
+     * POPULARITY_GRACE_PERIOD 와 THRESHOLD 애플리케이션(게시판) 특성에 맞게 적절하게 설정.
+     *
+     * 현재 인기글 기능은 없지만 해당 기능 추가 시 메모리 효율 증가 가능.
+     * 현재 tacker 가 생성된 모든 글을 관리하지만, 인기글 기능 도입 시 일반글 ->인기글로 진화한 글만 관리하면 됨.
+     *
+     *
+     *
+     * 조회수 손실 문제.
+     *
+     * T1: 게시글 조회로 tacker 에서 조회수 증가
+     * T2: tracker.remove(postId); 실행.
+     *
+     * 해당 상황 시 조회수 손실 발생 가능.
+     * 현재 조회수 관련 중요한 요구사항이 없고 손실이 발생한 글은 애초에 조회수 변화량이 적은 글이라 크게 문제될 거 없다고 판단.
+     * 만약, 중요하다고 판단 시 메시지큐 도입 혹은 트랜잭션 아웃박스 패턴 등 이용 가능.
+     *
+     */
+
+    public void flush() {
+        LocalDateTime now = LocalDateTime.now();
+        Map<Long, Integer> newCounts = tracker.drainAll();
+
+        for (Map.Entry<Long, Integer> entry : newCounts.entrySet()) {
+            Long postId = entry.getKey();
+            int newCount = entry.getValue();
+
+            ReadCountTracker.PreData preData = tracker.getPreData(postId);
+            if (preData == null) continue;
+
+            int preCount = preData.count;
+            LocalDateTime createdAt = preData.createdTime;
+
+            int delta = newCount - preCount;
+
+            // 조회수가 변한 글만 DB 반영
+            if (delta > 0) {
+                tracker.updatePreCount(postId, newCount);
+                recruitReviewRepository.updateViewCount(postId, newCount);
+            }
+
+            // 조회수 변화량이 적은 글이면 삭제해준다.
+            if (delta <= THRESHOLD && createdAt.isBefore(now.minus(POPULARITY_GRACE_PERIOD))) {
+                tracker.remove(postId);
+            }
+        }
+    }
+}

--- a/src/main/java/com/forwork/backend/api/recruit_review/service/ReadCountTracker.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/service/ReadCountTracker.java
@@ -1,0 +1,117 @@
+package com.forwork.backend.api.recruit_review.service;
+
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * db lock 으로 인한 성능 감소에 대비해 게시글의 조회수를 메모리에 올려 관리한다.
+ *
+ * newCountMap: tacker 가 관리하는 게시글의 조회수 key: recruitReviewId, value: readCount
+ * preCountMap: key: recruitReviewId value: PreData.count: 마지막 flush 시 조회수,  PreData.createdTime: 게시글 생성 시간.
+ *
+ * preCountMap 도입 이유.
+ *
+ * 모든 글을 tracker 가 관리하기엔 메모리 사용에 있어서 비율적임.
+ * db lock 으로 인한 성능 저하가 발생하는 게시글은 인기 있는 특정 게시글들임.
+ * 인기 없는 게시글 삭제를 위한 자료구조.
+ *
+ * 자세한 동작은 ReadCountFlusher.flush() 참고.
+ */
+
+//@Component
+public class ReadCountTracker {
+    private final ConcurrentHashMap<Long, AtomicInteger> newCountMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, PreData> preCountMap = new ConcurrentHashMap<>();
+
+
+    /**
+     * 조회수를 추적할 게시글을 tracker 에 등록.
+     */
+
+    public void init(Long recruitReviewId, LocalDateTime createdAt) {
+        newCountMap.put(recruitReviewId, new AtomicInteger(0));
+        preCountMap.put(recruitReviewId, new PreData(0, createdAt));
+    }
+
+    /**
+     * 해당 게시글이 tacker 에 있을 경우 1 증가시키고 리턴
+     * 없을 경우 -1을 리턴해준다.
+     *  -1로 리턴할 경우 직접 db에 update 해줘야 한다.
+     */
+
+    public int increment(Long recruitReviewId) {
+        AtomicInteger counter = newCountMap.get(recruitReviewId);
+        if (counter != null) {
+            return counter.incrementAndGet();
+        }
+        return -1;
+    }
+
+    /**
+     * 게시글들의 조회수를 리턴.
+     *  tracker 가 관리하지 않는 게시글이라면 -1로 리턴한다.
+     *  -1 일 경우 db 에서 조회해서 조회수 사용.
+     */
+
+    public Map<Long, Integer> getReadCounts(List<Long> recruitReviewIds) {
+        Map<Long, Integer> result = new HashMap<>();
+        for (Long recruitReviewId : recruitReviewIds) {
+            AtomicInteger counter = newCountMap.get(recruitReviewId);
+            result.put(recruitReviewId, counter != null ? counter.get() : -1);
+        }
+        return result;
+    }
+
+    /**
+     * flush 를 위해 현재 tracker 가 관리하는 조회수를 반환한다.
+     */
+
+    public Map<Long, Integer> drainAll() {
+        Map<Long, Integer> result = new HashMap<>();
+        for (Map.Entry<Long, AtomicInteger> entry : newCountMap.entrySet()) {
+            result.put(entry.getKey(), entry.getValue().get());
+        }
+        return result;
+    }
+
+    /**
+     * 마지막으로 flush 한 조회수를 기록한다.
+     */
+
+    public void updatePreCount(Long postId, int newCount) {
+        PreData old = preCountMap.get(postId);
+        if (old != null) {
+            preCountMap.put(postId, new PreData(newCount, old.createdTime));
+        }
+    }
+
+    public PreData getPreData(Long postId) {
+        return preCountMap.get(postId);
+    }
+
+
+    /**
+     * 해당 게시글은 tracker 에서 삭제.
+     */
+
+    public void remove(Long postId) {
+        newCountMap.remove(postId);
+        preCountMap.remove(postId);
+    }
+
+    public static class PreData {
+        public final int count; // 마지막 flush 시 조회수
+        public final LocalDateTime createdTime; // 게시글 생성 시간
+
+        public PreData(int count, LocalDateTime createdTime) {
+            this.count = count;
+            this.createdTime = createdTime;
+        }
+    }
+}

--- a/src/main/java/com/forwork/backend/api/recruit_review/service/RecruitReviewCommentService.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/service/RecruitReviewCommentService.java
@@ -170,13 +170,19 @@ public class RecruitReviewCommentService {
             return null;
         }
 
-        // 자식인 경우 -> parent
-        RecruitReviewComment parentComment = reviewCommentRepository.findParentCommentIfRoot(parentId)
+        RecruitReviewComment parentComment = reviewCommentRepository.findByIdWithParent(parentId)
                 .orElseThrow(() -> {
                     log.warn("[getParentComment][parent comment is not found][parentId= {}]", parentId);
                     return new NotFoundException(PARENT_COMMENT_NOT_FOUND_EXCEPTION.getMessage());
                 });
 
-        return parentComment;
+
+        // parentId 가 진짜 부모
+        if(parentComment.getParent()==null){
+            return parentComment;
+        }
+        else{ // 사실 형제 Id
+            return parentComment.getParent();
+        }
     }
 }

--- a/src/main/java/com/forwork/backend/api/recruit_review/service/RecruitReviewService.java
+++ b/src/main/java/com/forwork/backend/api/recruit_review/service/RecruitReviewService.java
@@ -7,7 +7,7 @@ import com.forwork.backend.api.recruit_review.dto.request.RecruitReviewCreateDTO
 import com.forwork.backend.api.recruit_review.dto.request.RecruitReviewUpdateDTO;
 import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewDetailResponseDTO;
 import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewPreviewResponseDTO;
-import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewToTalCountResponseDTO;
+import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewTotalCountResponseDTO;
 import com.forwork.backend.api.recruit_review.entity.RecruitReview;
 import com.forwork.backend.api.recruit_review.enums.RecruitReviewSortType;
 import com.forwork.backend.api.recruit_review.repository.RecruitReviewCommentRepository;
@@ -44,7 +44,7 @@ public class RecruitReviewService {
      * 채용 후기 생성
      *
      */
-    public void createRecruitReview(Long memberId, RecruitReviewCreateDTO dto) {
+    public Long createRecruitReview(Long memberId, RecruitReviewCreateDTO dto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
                     log.warn("[createRecruitReview][member is not found][memberId= {}]", memberId);
@@ -53,8 +53,12 @@ public class RecruitReviewService {
 
         RecruitReview recruitReview = dto.toEntity(member);
 
-        recruitReviewRepository.save(recruitReview);
+        RecruitReview review = recruitReviewRepository.save(recruitReview);
 
+        // readCountTracker 에 등록.
+//        readCountTracker.init(review.getId(), review.getCreatedAt());
+
+        return review.getId();
     }
 
 
@@ -66,13 +70,14 @@ public class RecruitReviewService {
      * @apiNote 채용 후기 단건 조회
      */
     public RecruitReviewDetailResponseDTO getRecruitReview(Long memberId, Long recruitReviewId) {
+        // 조회수 증가 및 조회
+        Integer readCount = incrementReadCount(recruitReviewId);
+
         RecruitReview recruitReview = recruitReviewRepository.findByIdWithWriter(recruitReviewId)
                 .orElseThrow(() -> {
                     log.warn("[getRecruitReview][recruitReview is not found][recruitReviewId= {}]", recruitReviewId);
                     return new NotFoundException(RECRUIT_REVIEW_NOT_FOUND_EXCEPTION.getMessage());
                 });
-
-        recruitReviewRepository.incrementReadCount(recruitReviewId);
 
         Member writer = recruitReview.getWriter();
 
@@ -82,7 +87,7 @@ public class RecruitReviewService {
         // isMine
         boolean isMin= Objects.equals(memberId, writer.getId());
 
-        RecruitReviewDetailResponseDTO response = RecruitReviewDetailResponseDTO.of(recruitReview, commentCount, isMin, writer);
+        RecruitReviewDetailResponseDTO response = RecruitReviewDetailResponseDTO.of(recruitReview, commentCount, isMin, writer, readCount);
 
         return response;
     }
@@ -91,9 +96,18 @@ public class RecruitReviewService {
      * @apiNote 채용 후기 페이징
      */
     public PageResponseDTO<RecruitReviewPreviewResponseDTO> getRecruitPreviews(String keyword, Integer page, Integer size, RecruitReviewSortType sortType) {
+
         Pageable pageable= PageRequest.of(page, size);
 
         Page<RecruitReviewPreviewInternalDTO> recruitPreviews = recruitReviewRepository.getRecruitPreviews(keyword, pageable, sortType);
+
+        /*// tracker 에 존재하는 조회수 갖고 온다.
+        List<Long> ids=recruitPreviews.stream()
+                .map(RecruitReviewPreviewInternalDTO::recruitReviewId)
+                .toList();
+
+        // key: recruitReviewId, readCount
+        Map<Long, Integer> readCounts = readCountTracker.getReadCounts(ids);*/
 
         Page<RecruitReviewPreviewResponseDTO> map = recruitPreviews
                                                     .map(RecruitReviewPreviewResponseDTO::of);
@@ -106,10 +120,10 @@ public class RecruitReviewService {
     /**
      * @apiNote  후기 totalCount 조회
      */
-    public RecruitReviewToTalCountResponseDTO getRecruitReviewTotalCount(){
+    public RecruitReviewTotalCountResponseDTO getRecruitReviewTotalCount(){
         Long l = recruitReviewRepository.fineToTalCount();
 
-        return new RecruitReviewToTalCountResponseDTO(l);
+        return new RecruitReviewTotalCountResponseDTO(l);
     }
 
     /*
@@ -162,6 +176,17 @@ public class RecruitReviewService {
         }
     }
 
+    private Integer incrementReadCount(Long recruitReviewId) {
+        int readCount = -1;
+
+//        readCount = readCountTracker.increment(recruitReviewId);
+
+        if (readCount == -1) {
+            recruitReviewRepository.incrementReadCount(recruitReviewId);
+        }
+
+        return readCount;
+    }
 
 
 }

--- a/src/test/java/com/forwork/backend/api/recruit_review/service/RecruitReviewServiceTest.java
+++ b/src/test/java/com/forwork/backend/api/recruit_review/service/RecruitReviewServiceTest.java
@@ -1,0 +1,254 @@
+package com.forwork.backend.api.recruit_review.service;
+
+import com.forwork.backend.api.member.entity.*;
+import com.forwork.backend.api.member.repository.MemberRepository;
+import com.forwork.backend.api.recruit_review.dto.request.RecruitReviewCreateDTO;
+import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewDetailResponseDTO;
+import com.forwork.backend.api.recruit_review.dto.response.RecruitReviewPreviewResponseDTO;
+import com.forwork.backend.api.recruit_review.entity.RecruitReview;
+import com.forwork.backend.api.recruit_review.enums.RecruitReviewSortType;
+import com.forwork.backend.api.recruit_review.repository.RecruitReviewRepository;
+import com.forwork.backend.common.dto.PageResponseDTO;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@Transactional
+class RecruitReviewServiceTest {
+
+    @Autowired
+    private RecruitReviewService recruitReviewService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+//    @Autowired
+    private ReadCountTracker readCountTracker;
+
+//    @Autowired
+    private ReadCountFlusher readCountFlusher;
+
+    @Autowired
+    private RecruitReviewRepository recruitReviewRepository;
+
+    private Member member;
+
+
+
+    @BeforeEach
+    void setup(){
+        Address address = new Address("zipcode", "address1", "address2");
+
+        Employee employee = new Employee(
+                "testUserId",
+                "password123!",
+                "홍길동",
+                "test@example.com",
+                "01012345678",
+                address,
+                "대한민국",      // nationality
+                "대학졸업",      // education
+                "F-2",          // visa
+                LocalDate.now(),
+                Gender.MALE,
+                true,  // termsOfServiceAgreement
+                true,  // isOver15
+                true,  // personalInfoAgreement
+                false, // adInfoAgreementSmsMms
+                false  // adInfoAgreementEmail
+        );
+
+
+        member= memberRepository.save(employee);
+    }
+
+    @Test
+    void test(){
+
+    }
+
+
+    /**
+     * 게시글 생성 시 tracker 의 newCounts 들어가나 확인.
+     */
+
+    @Test
+    void 게시글_생성(){
+        // given
+        RecruitReviewCreateDTO dto = new RecruitReviewCreateDTO("title", "content", "region1", "region2", JobCategory.CONSTRUCTION);
+
+
+        // when
+        Long id = recruitReviewService.createRecruitReview(member.getId(), dto);
+
+
+        // then
+
+        Map<Long, Integer> readCounts = readCountTracker.getReadCounts(List.of(id));
+        Integer i = readCounts.get(id);
+
+        assertEquals(0, i);
+    }
+
+    /**
+     * 게시글 조회 시 tracker 에 조회수 업데이트와 유저에게 보여줄 조회수 확인.
+     * 총 5번 조회헀으므로 둘 다 5인지 테스트
+     * flush 전이므로 DB 에 있는 조회수는 0이어야 함.
+     */
+
+    @Test
+    void 게시글_조회(){
+        // given
+        RecruitReviewCreateDTO dto = new RecruitReviewCreateDTO("title", "content", "region1", "region2", JobCategory.CONSTRUCTION);
+        Long id = recruitReviewService.createRecruitReview(member.getId(), dto);
+
+        // when
+
+        int targetReadCount=5;
+
+        for(int i = 0; i < targetReadCount-1; i++){
+            recruitReviewService.getRecruitReview(member.getId(), id);
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+
+        RecruitReviewDetailResponseDTO recruitReview = recruitReviewService.getRecruitReview(member.getId(), id);
+
+        // then
+
+        Map<Long, Integer> readCounts = readCountTracker.getReadCounts(List.of(id));
+        Integer i = readCounts.get(id);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        long readCount = recruitReviewRepository.findById(id).get().getReadCount();
+
+        assertEquals(targetReadCount, i);
+        assertEquals(targetReadCount, recruitReview.readCount());
+        assertEquals(0, readCount);
+
+    }
+
+    /**
+     * 게시글 전체 조회 시 조회수 확인
+     * 조회수가 0, 3 그리고 5인 게시글 총 3개
+     */
+
+    @Test
+    void 게시글_페이징(){
+        // given
+
+        RecruitReviewCreateDTO dto = new RecruitReviewCreateDTO("title", "content", "region1", "region2", JobCategory.CONSTRUCTION);
+        Long readCount0 = recruitReviewService.createRecruitReview(member.getId(), dto);
+        Long readCount3 = recruitReviewService.createRecruitReview(member.getId(), dto);
+        Long readCount5 = recruitReviewService.createRecruitReview(member.getId(), dto);
+
+        for(int i=0;i<3;i++){
+            recruitReviewService.getRecruitReview(member.getId(), readCount3);
+        }
+
+        for(int i=0;i<5;i++){
+            recruitReviewService.getRecruitReview(member.getId(), readCount5);
+        }
+
+        // when
+
+        PageResponseDTO<RecruitReviewPreviewResponseDTO> recruitPreviews = recruitReviewService.getRecruitPreviews(null, 0, 10, RecruitReviewSortType.LATEST);
+
+
+        // then
+        List<RecruitReviewPreviewResponseDTO> content = recruitPreviews.getContent();
+
+        Map<Long, Long> readCountMap = content.stream()
+                .collect(Collectors.toMap(
+                        RecruitReviewPreviewResponseDTO::recruitReviewId,
+                        RecruitReviewPreviewResponseDTO::readCount
+                ));
+
+        assertEquals(0, readCountMap.get(readCount0));
+        assertEquals(3, readCountMap.get(readCount3));
+        assertEquals(5, readCountMap.get(readCount5));
+
+    }
+
+    /**
+     * flush 실행 시 db 반영되나 확인.
+     */
+
+    @Test
+    void db_flush(){
+        // given
+        RecruitReviewCreateDTO dto = new RecruitReviewCreateDTO("title", "content", "region1", "region2", JobCategory.CONSTRUCTION);
+        Long id = recruitReviewService.createRecruitReview(member.getId(), dto);
+
+        int targetReadCount=5;
+
+        for(int i = 0; i < targetReadCount; i++){
+            recruitReviewService.getRecruitReview(member.getId(), id);
+        }
+
+        // when
+
+        readCountFlusher.flush();
+
+
+        entityManager.flush();
+        entityManager.clear();
+
+
+        // then
+        RecruitReview recruitReview = recruitReviewRepository.findById(id).get();
+
+        Map<Long, Integer> readCounts = readCountTracker.getReadCounts(List.of(id));
+        Integer i = readCounts.get(id);
+
+        assertEquals(targetReadCount, i);
+        assertEquals(targetReadCount, recruitReview.getReadCount());
+    }
+
+    /**
+     * 조회수 변화량 많은 글은 tacker 에 유지되고 적은 글은 삭제됨.
+     */
+
+    @Test
+    void 조회수_변화량_많은_글은_유지되고_적은_글은_삭제된다() {
+        // given
+        RecruitReviewCreateDTO dto = new RecruitReviewCreateDTO("title", "content", "region1", "region2", JobCategory.CONSTRUCTION);
+        Long hot = recruitReviewService.createRecruitReview(member.getId(), dto);
+        Long cold=recruitReviewService.createRecruitReview(member.getId(), dto);
+
+        int readCount=10000;
+
+        for(int i=0;i<readCount;i++){
+            recruitReviewService.getRecruitReview(member.getId(), hot);
+        }
+
+        // when
+
+        readCountFlusher.flush();
+
+        // then
+
+        Map<Long, Integer> readCounts = readCountTracker.getReadCounts(List.of(hot, cold));
+
+        assertEquals(readCount, readCounts.get(hot));
+        assertEquals(-1, readCounts.get(cold));
+    }
+
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #12 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 조회수 최적화 기능 구현 (현재는 기능 off)

- 대댓글 조회 시 일부 수정
- 기존: only 부모 댓글 id를 넘겨야 대댓글 작성 가능. 형제 댓글 id 시 작성 불가
- 변경: 형제 댓글 id 넘겨도 부모 찾아 대댓글 작성 가능


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->

- <문제 상황>
- 트래픽이 몰릴 경우 조회수 업데이트 시 db lock으로 인한 성능 저하 발생.

- <해결 방안>
- 매번 update 쿼리를 날리는 게 아닌 메모리에 캐싱하여 배치 처리로 진행.
- 메모리에 조회수 기록했다가 일정 시간 후 db에 flush
- 모든 글을 캐시하기엔 비효율적이어서 일부 게시글만 캐시하는 전략 선택.

- <한계>
- 1) 서버 메모리에서 처리하여 글이 많아질 경우  한계 -> 인기글 기능 도입 그래도 부족할 시 redis 이용
- 2) 서버 다운 시 조회수 손실 가능하여 graceful shutdown 보장 필요
- 3) thread 간 스케줄링에 따라 조회수 손실 문제 발생 -> 메시지 큐 도입 혹은 트랜잭션 아웃박스 패턴 이용


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 형제 댓글로 대댓글 조회 성공
![댓글 등록 성공](https://github.com/user-attachments/assets/8e271883-c57a-453f-87ee-59e3e5026c1b)

- 조회수 최적화 기능은 Test 코드 참고
