### PR TITLE
[FEAT] 문의하기 답변 상태 조회하는 api 추가.

### DIFF
--- a/src/main/java/com/forwork/backend/api/mypage/dto/response/ArchiveInquiryResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/mypage/dto/response/ArchiveInquiryResponseDTO.java
@@ -10,7 +10,9 @@ public record ArchiveInquiryResponseDTO(
         String title,
         @Schema(description = "문의")
         String inquiry,
-        @Schema(description = "답변. null 이면 답변 x")
+        @Schema(description = "답변 유무")
+        boolean isAnswered,
+        @Schema(description = "답변.")
         String answer
 ) {
 
@@ -19,6 +21,7 @@ public record ArchiveInquiryResponseDTO(
                 archiveInquiry.getId(),
                 archiveInquiry.getArchive().getTitle(),
                 archiveInquiry.getInquiry(),
+                archiveInquiry.isAnswered(),
                 archiveInquiry.getAnswer()
         );
     }

--- a/src/main/java/com/forwork/backend/api/mypage/service/EmployeeMyPageService.java
+++ b/src/main/java/com/forwork/backend/api/mypage/service/EmployeeMyPageService.java
@@ -6,6 +6,7 @@ import com.forwork.backend.api.order.dto.query.PassArchivePreviewIdAndPaymentApp
 import com.forwork.backend.api.order.repository.OrderRepository;
 import com.forwork.backend.api.pass_archive.entity.ArchiveReview;
 import com.forwork.backend.api.pass_archive.entity.PassArchive;
+import com.forwork.backend.api.pass_archive.repository.ArchiveInquiryRepository;
 import com.forwork.backend.api.pass_archive.repository.ArchiveReviewRepository;
 import com.forwork.backend.api.pass_archive.repository.PassArchiveRepository;
 import com.forwork.backend.api.pass_archive.service.ArchiveInquiryReader;
@@ -31,6 +32,7 @@ public class EmployeeMyPageService {
     private final PassArchiveRepository passArchiveRepository;
     private final ArchiveReviewRepository archiveReviewRepository;
     private final ArchiveInquiryReader archiveInquiryReader;
+    private final ArchiveInquiryRepository archiveInquiryRepository;
 
     /*
     * r
@@ -116,6 +118,14 @@ public class EmployeeMyPageService {
     public PageResponseDTO<ArchiveInquiryResponseDTO> getReceivedInquiries(Long receiverId, Integer page, Integer size) {
         Pageable pageable= PageRequest.of(page, size);
         Page<ArchiveInquiryResponseDTO> archiveInquiries = archiveInquiryReader.getReceivedInquiries(receiverId, pageable).map(ArchiveInquiryResponseDTO::of);
+
+        // 문의 읽음 처리
+        List<Long> inquiryIds = archiveInquiries.getContent().stream()
+                .map(ArchiveInquiryResponseDTO::archiveInquiryId)
+                .toList();
+
+        archiveInquiryRepository.markAsRead(inquiryIds);
+
         PageResponseDTO<ArchiveInquiryResponseDTO> response = PageResponseDTO.of(archiveInquiries);
         return response;
     }

--- a/src/main/java/com/forwork/backend/api/pass_archive/controller/PassArchiveController.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/controller/PassArchiveController.java
@@ -59,9 +59,12 @@ public class PassArchiveController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "합격 아카이브를 찾을 수 없습니다.")
     })
     @GetMapping("/detail")
-    public ResponseEntity<ApiResponse<PassArchiveDetailResponseDTO>> getDetail(@RequestParam("id") Long id) {
+    public ResponseEntity<ApiResponse<PassArchiveDetailResponseDTO>> getDetail(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                               @RequestParam("id") Long id) {
 
-        PassArchiveDetailResponseDTO passArchiveDetailResponseDTO = passArchiveService.getDetailArchive(id);
+        Long memberId = (securityMember==null)?null: securityMember.getId();
+
+        PassArchiveDetailResponseDTO passArchiveDetailResponseDTO = passArchiveService.getDetailArchive(memberId, id);
         return ApiResponse.success(SuccessStatus.SEND_PASS_ARCHIVE_DETAIL_SUCCESS, passArchiveDetailResponseDTO);
     }
 
@@ -194,6 +197,49 @@ public class PassArchiveController {
     ) {
         PageResponseDTO<PassArchivePreviewResponseDTO> response = passArchiveService.getPassArchives(keyword, page, size);
         return ApiResponse.success(SuccessStatus.SEND_PASS_ARCHIVE_ALL_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "문의하기 답변 달렸는지 확인. API (용범)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "문의 답변 유무 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문의글을 찾을 수 없습니다."),
+    })
+    @GetMapping("/inquiries/{inquiry-id}/is-answered")
+    public ResponseEntity<ApiResponse<Boolean>> isAnswered(@AuthenticationPrincipal SecurityMember securityMember,
+                                                           @PathVariable("inquiry-id") Long inquiryId) {
+        boolean answered = archiveInquiryService.isAnswered(inquiryId);
+
+        return ApiResponse.success(SuccessStatus.CHECK_INQUIRY_ANSWERED_SUCCESS, answered);
+    }
+
+    @Operation(
+            summary = "내가 보낸 문의 중 가장 최근 거 조회. API (용범)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "내가 보낸 최근 문의 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "문의글을 찾을 수 없습니다."),
+    })
+    @GetMapping("/latest-inquiry")
+    public ResponseEntity<ApiResponse<LatestInquiryResponseDTO>> getLatestInquiry(@AuthenticationPrincipal SecurityMember securityMember) {
+        LatestInquiryResponseDTO response = archiveInquiryService.getLatestInquiry(securityMember.getId());
+
+        return ApiResponse.success(SuccessStatus.GET_LATEST_MY_INQUIRY_SUCCESS, response);
+    }
+
+    @Operation(
+            summary = "새로운 문의가 있나?. API (용범)"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "특정 아카이브 읽지 않은 문의 조회 성공"),
+    })
+    @GetMapping("/{pass-archive-id}/inquiries/unread")
+    public ResponseEntity<ApiResponse<Boolean>> hasUnreadInquiryForArchive(@AuthenticationPrincipal SecurityMember securityMember,
+                                                                           @PathVariable("pass-archive-id") Long archiveId) {
+        boolean response = archiveInquiryService.hasUnreadInquiryForArchive(archiveId);
+
+        return ApiResponse.success(SuccessStatus.CHECK_UNREAD_INQUIRY_SUCCESS, response);
     }
 
     /*

--- a/src/main/java/com/forwork/backend/api/pass_archive/dto/LatestInquiryResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/dto/LatestInquiryResponseDTO.java
@@ -1,0 +1,38 @@
+package com.forwork.backend.api.pass_archive.dto;
+
+import com.forwork.backend.api.member.entity.Member;
+import com.forwork.backend.api.pass_archive.entity.ArchiveInquiry;
+import com.forwork.backend.api.pass_archive.entity.PassArchive;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LatestInquiryResponseDTO(
+        @Schema(description = "유저명")
+        String name,
+        @Schema(description = "제목")
+        String title,
+        @Schema(description = "한 줄설명")
+        String oneLineReview,
+        @Schema(description = "가격")
+        long price,
+        @Schema(description = "문의")
+        String inquiry,
+        @Schema(description = "답변 유무")
+        boolean isAnswered,
+        @Schema(description = "답변.")
+        String answer
+) {
+    public static LatestInquiryResponseDTO of(ArchiveInquiry archiveInquiry) {
+        PassArchive archive = archiveInquiry.getArchive();
+        Member archiveOwner = archive.getMember();
+
+        return new LatestInquiryResponseDTO(
+                archiveOwner.getName(),
+                archive.getTitle(),
+                archive.getOneLineReview(),
+                archive.getPrice(),
+                archiveInquiry.getInquiry(),
+                archiveInquiry.isAnswered(),
+                archiveInquiry.getAnswer()
+        );
+    }
+}

--- a/src/main/java/com/forwork/backend/api/pass_archive/dto/LatestInquiryResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/dto/LatestInquiryResponseDTO.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record LatestInquiryResponseDTO(
         @Schema(description = "id")
         Long archiveInquiryId,
-        @Schema(description = "")
+        @Schema(description = "프로필 이미지")
         String profileImage,
         @Schema(description = "유저명")
         String name,

--- a/src/main/java/com/forwork/backend/api/pass_archive/dto/LatestInquiryResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/dto/LatestInquiryResponseDTO.java
@@ -6,6 +6,10 @@ import com.forwork.backend.api.pass_archive.entity.PassArchive;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LatestInquiryResponseDTO(
+        @Schema(description = "id")
+        Long archiveInquiryId,
+        @Schema(description = "")
+        String profileImage,
         @Schema(description = "유저명")
         String name,
         @Schema(description = "제목")
@@ -26,6 +30,8 @@ public record LatestInquiryResponseDTO(
         Member archiveOwner = archive.getMember();
 
         return new LatestInquiryResponseDTO(
+                archiveInquiry.getId(),
+                archiveOwner.getProfileImage(),
                 archiveOwner.getName(),
                 archive.getTitle(),
                 archive.getOneLineReview(),

--- a/src/main/java/com/forwork/backend/api/pass_archive/dto/PassArchiveDetailResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/dto/PassArchiveDetailResponseDTO.java
@@ -21,8 +21,9 @@ public class PassArchiveDetailResponseDTO {
     private List<String> imageUrls;
     private String authorNickname;
     private String authorProfileImage;
+    private boolean isWriter;
 
-    public static PassArchiveDetailResponseDTO from(PassArchive pa) {
+    public static PassArchiveDetailResponseDTO from(PassArchive pa, boolean isWriter) {
         return new PassArchiveDetailResponseDTO(
                 pa.getTitle(),
                 pa.getOneLineReview(),
@@ -35,7 +36,8 @@ public class PassArchiveDetailResponseDTO {
                         .map(UploadFile::getFileUrl)
                         .collect(Collectors.toList()),
                 pa.getMember().getName(),            // name을 닉네임으로 사용
-                pa.getMember().getProfileImage()     // Member.profileImage
+                pa.getMember().getProfileImage(),     // Member.profileImage
+                isWriter
         );
     }
 }

--- a/src/main/java/com/forwork/backend/api/pass_archive/entity/ArchiveInquiry.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/entity/ArchiveInquiry.java
@@ -25,6 +25,9 @@ public class ArchiveInquiry extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String answer;
 
+    private boolean isReadByArchiveWriter;
+    private boolean isAnswered;
+
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "inquirer _id")
     private Member inquirer ;
@@ -36,5 +39,7 @@ public class ArchiveInquiry extends BaseTimeEntity {
 
     public void answer(String answer) {
         this.answer = answer;
+        this.isAnswered = true;
+        this.isReadByArchiveWriter = true;
     }
 }

--- a/src/main/java/com/forwork/backend/api/pass_archive/repository/ArchiveInquiryRepository.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/repository/ArchiveInquiryRepository.java
@@ -4,9 +4,12 @@ import com.forwork.backend.api.pass_archive.entity.ArchiveInquiry;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ArchiveInquiryRepository extends JpaRepository<ArchiveInquiry, Long> {
@@ -26,6 +29,19 @@ public interface ArchiveInquiryRepository extends JpaRepository<ArchiveInquiry, 
 
 
     @Query("select ai from ArchiveInquiry ai" +
+            " join fetch ai.archive a" +
+            " join fetch a.member" +
+            " where ai.inquirer.id=:inquirerId" +
+            " order by ai.id desc" +
+            " limit 1")
+    Optional<ArchiveInquiry> findLatestInquiryByArchiveInquiryIdAndInquirerId(@Param("inquirerId") Long inquirerId);
+
+    @Query("select count(*)>0 from ArchiveInquiry ai" +
+            " where ai.archive.passArchiveId=:archiveId and ai.isReadByArchiveWriter=false")
+    boolean existsUnreadInquiryForArchive(@Param("archiveId") Long archiveId);
+
+
+    @Query("select ai from ArchiveInquiry ai" +
             " join fetch ai.archive" +
             " where ai.inquirer.id=:inquirerId" +
             " order by ai.id desc")
@@ -38,4 +54,8 @@ public interface ArchiveInquiryRepository extends JpaRepository<ArchiveInquiry, 
             " order by ai.id desc")
     Page<ArchiveInquiry>findReceivedInquiriesByReceiverId(@Param("receiverId") Long receiverId, Pageable pageable);
 
+
+    @Modifying @Transactional
+    @Query("update ArchiveInquiry ai set ai.isReadByArchiveWriter=true where ai.id in :inquiryIds")
+    void markAsRead(@Param("inquiryIds") List<Long> inquiryIds);
 }

--- a/src/main/java/com/forwork/backend/api/pass_archive/service/ArchiveInquiryReader.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/service/ArchiveInquiryReader.java
@@ -2,11 +2,14 @@ package com.forwork.backend.api.pass_archive.service;
 
 import com.forwork.backend.api.pass_archive.entity.ArchiveInquiry;
 import com.forwork.backend.api.pass_archive.repository.ArchiveInquiryRepository;
+import com.forwork.backend.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+
+import static com.forwork.backend.common.response.ErrorStatus.INQUIRY_NOT_FOUND_EXCEPTION;
 
 @Component
 @RequiredArgsConstructor
@@ -29,5 +32,38 @@ public class ArchiveInquiryReader {
     public Page<ArchiveInquiry> getReceivedInquiries(Long receiverId, Pageable pageable) {
         Page<ArchiveInquiry> archiveInquiries = archiveInquiryRepository.findReceivedInquiriesByReceiverId(receiverId, pageable);
         return archiveInquiries;
+    }
+
+    /**
+     * 문의 답변 유무 조회
+     */
+    public boolean isAnswered(Long archiveInquiryId){
+        ArchiveInquiry archiveInquiry = archiveInquiryRepository.findById(archiveInquiryId)
+                .orElseThrow(() -> {
+                    log.warn("[isAnswered][문의 없음.][archiveInquiryId={}]", archiveInquiryId);
+                    return new NotFoundException(INQUIRY_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        return archiveInquiry.isAnswered();
+    }
+
+    /**
+     * 내가 보낸 문의 중 가장 최근 거 조회
+     */
+    public ArchiveInquiry getLatestInquiry(Long inquirerId) {
+        ArchiveInquiry archiveInquiry = archiveInquiryRepository.findLatestInquiryByArchiveInquiryIdAndInquirerId(inquirerId)
+                .orElseThrow(() -> {
+                    log.warn("[getLatestInquiry][문의 없음.][inquirerId={}]", inquirerId);
+                    return new NotFoundException(INQUIRY_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        return archiveInquiry;
+    }
+
+    /**
+     * 특정 아카이브에 대해 읽지 않은 문의가 있어?
+     */
+    public boolean hasUnreadInquiryForArchive(Long archiveId) {
+        return archiveInquiryRepository.existsUnreadInquiryForArchive(archiveId);
     }
 }

--- a/src/main/java/com/forwork/backend/api/pass_archive/service/ArchiveInquiryService.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/service/ArchiveInquiryService.java
@@ -6,6 +6,7 @@ import com.forwork.backend.api.notification.entity.ArchiveInquiryNotification;
 import com.forwork.backend.api.notification.enums.ArchiveInquiryNotificationType;
 import com.forwork.backend.api.notification.repository.ArchiveInquiryNotificationRepository;
 import com.forwork.backend.api.pass_archive.dto.ArchiveInquiryAnswerResponseDTO;
+import com.forwork.backend.api.pass_archive.dto.LatestInquiryResponseDTO;
 import com.forwork.backend.api.pass_archive.entity.ArchiveInquiry;
 import com.forwork.backend.api.pass_archive.entity.PassArchive;
 import com.forwork.backend.api.pass_archive.repository.ArchiveInquiryRepository;
@@ -29,6 +30,7 @@ public class ArchiveInquiryService {
     private final MemberRepository memberRepository;
     private final PassArchiveRepository passArchiveRepository;
     private final ArchiveInquiryNotificationRepository archiveInquiryNotificationRepository;
+    private final ArchiveInquiryReader archiveInquiryReader;
 
 
 
@@ -59,6 +61,8 @@ public class ArchiveInquiryService {
                 .archive(passArchive)
                 .inquiry(content)
                 .inquirer(inquirer)
+                .isAnswered(false)
+                .isReadByArchiveWriter(false)
                 .build();
 
         archiveInquiryRepository.save(archiveInquiry);
@@ -91,7 +95,7 @@ public class ArchiveInquiryService {
             throw new BadRequestException(UNAUTHORIZED_INQUIRY_ANSWER_EXCEPTION.getMessage());
         }
 
-        if(archiveInquiry.getAnswer()!= null){
+        if(archiveInquiry.isAnswered()){
             log.warn("[answer][이미 답변했음][archiveInquiryId= {}]", archiveInquiryId);
             throw new BadRequestException(ANSWER_ALREADY_EXISTS_EXCEPTION.getMessage());
         }
@@ -122,4 +126,28 @@ public class ArchiveInquiryService {
         return ArchiveInquiryAnswerResponseDTO.of(archiveInquiry);
     }
 
+    /**
+     * 문의 답변 유무 조회
+     */
+    public boolean isAnswered(Long archiveInquiryId){
+        return archiveInquiryReader.isAnswered(archiveInquiryId);
+    }
+
+    /**
+     * 내가 보낸 문의 중 가장 최근 거 조회
+     */
+    public LatestInquiryResponseDTO getLatestInquiry(Long inquirerId) {
+        ArchiveInquiry latestInquiry = archiveInquiryReader.getLatestInquiry(inquirerId);
+
+        LatestInquiryResponseDTO response = LatestInquiryResponseDTO.of(latestInquiry);
+
+        return response;
+    }
+
+    /**
+     * 특정 아카이브에 대해 읽지 않은 문의가 있어?
+     */
+    public boolean hasUnreadInquiryForArchive(Long archiveId) {
+        return archiveInquiryReader.hasUnreadInquiryForArchive(archiveId);
+    }
 }

--- a/src/main/java/com/forwork/backend/api/pass_archive/service/PassArchiveService.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/service/PassArchiveService.java
@@ -74,12 +74,16 @@ public class PassArchiveService {
 
     // 합격 아카이브 상세 조회
     @Transactional(readOnly = true)
-    public PassArchiveDetailResponseDTO getDetailArchive(Long passArchiveId) {
+    public PassArchiveDetailResponseDTO getDetailArchive(Long memberId, Long passArchiveId) {
 
         PassArchive passArchive = passArchiveRepository.findWithThumbnailImagesMemberByPassArchiveId(passArchiveId)
                 .orElseThrow(() -> new NotFoundException(ErrorStatus.PASS_ARCHIVE_NOT_FOUND_EXCEPTION.getMessage()));
 
-        return PassArchiveDetailResponseDTO.from(passArchive);
+        // 작성자인지 판단
+        Member writer = passArchive.getMember();
+        boolean isWriter= writer.getId().equals(memberId);
+
+        return PassArchiveDetailResponseDTO.from(passArchive, isWriter);
     }
 
     // 아카이브 다운

--- a/src/main/java/com/forwork/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/forwork/backend/common/response/SuccessStatus.java
@@ -95,6 +95,9 @@ public enum SuccessStatus {
     READ_NOTIFICATIONS_SUCCESS(HttpStatus.OK, "알림 읽음 처리 성공"),
     SEND_ANSWER_SUCCESS(HttpStatus.OK, "답변 보기 성공"),
     SEND_PASS_ARCHIVE_ALL_SUCCESS(HttpStatus.OK, "합격 아카이브 전체 조회 성공"),
+    CHECK_INQUIRY_ANSWERED_SUCCESS(HttpStatus.OK, "문의 답변 유무 조회 성공"),
+    GET_LATEST_MY_INQUIRY_SUCCESS(HttpStatus.OK, "내가 보낸 최근 문의 조회 성공"),
+    CHECK_UNREAD_INQUIRY_SUCCESS(HttpStatus.OK, "특정 아카이브 읽지 않은 문의 조회 성공"),
 
 
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #39 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 문의하기 답변 유무 조회.
- 내가 보낸 문의 중 가장 최근 문의 조회.
- 확인하지 않은 문의 있는지 조회.


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->


## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 문의하기 답변 유무 조회.
<img width="1751" height="360" alt="문의 답변 유무 조회 성공" src="https://github.com/user-attachments/assets/d542bb78-ca89-48f9-930d-54f79c9ad0e4" />
- 내가 보낸 문의 중 가장 최근 문의 조회.
<img width="1750" height="496" alt="보낸 문의 중 가장 최근 문의 조회 성공" src="https://github.com/user-attachments/assets/cecc9836-ae3e-4c6e-a73a-b84edf4fc05c" />
- 확인하지 않은 문의 있는지 조회.
<img width="1773" height="365" alt="읽지 않은 문의가 있나" src="https://github.com/user-attachments/assets/30550be9-382c-4801-bb58-e6bbc327301f" />


