### PR TITLE
[FEAT] 판매한 아카이브 인출 요청 구현

### DIFF
--- a/src/main/java/com/forwork/backend/api/mypage/dto/response/SoldArchiveResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/mypage/dto/response/SoldArchiveResponseDTO.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
 public record SoldArchiveResponseDTO(
+        @Schema(description = "구매 내역 id")
+        Long paymentId,
         @Schema(description = "아카이브 id")
         Long archiveId,
         @Schema(description = "제목")
@@ -25,6 +27,7 @@ public record SoldArchiveResponseDTO(
 
         public static SoldArchiveResponseDTO of(Payment payment, PassArchive passArchive) {
                 return new SoldArchiveResponseDTO(
+                        payment.getId(),
                         passArchive.getPassArchiveId(),
                         passArchive.getTitle(),
                         passArchive.getOneLineReview(),

--- a/src/main/java/com/forwork/backend/api/order/repository/OrderPassArchiveRepository.java
+++ b/src/main/java/com/forwork/backend/api/order/repository/OrderPassArchiveRepository.java
@@ -2,7 +2,6 @@ package com.forwork.backend.api.order.repository;
 
 import com.forwork.backend.api.mypage.dto.query.ArchiveSalesCountQueryDTO;
 import com.forwork.backend.api.order.entity.OrderPassArchive;
-import com.forwork.backend.api.pass_archive.entity.PassArchive;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,4 +23,8 @@ public interface OrderPassArchiveRepository extends JpaRepository<OrderPassArchi
             " join fetch opa.passArchive a" +
             " where o.id in :orderIds")
     List<OrderPassArchive> findAllByOrderIds(@Param("orderIds") List<Long> orderIds);
+
+    @Query("select distinct opa.passArchive.passArchiveId from OrderPassArchive opa" +
+            " where opa.order.id in :orderIds")
+    List<Long> findArchiveIdsByOrderIds(@Param("orderIds") List<Long> orderIds);
 }

--- a/src/main/java/com/forwork/backend/api/pass_archive/repository/PassArchiveRepository.java
+++ b/src/main/java/com/forwork/backend/api/pass_archive/repository/PassArchiveRepository.java
@@ -24,6 +24,11 @@ public interface PassArchiveRepository extends JpaRepository<PassArchive, Long>,
     List<PassArchive> findAllByIds(@Param("ids") List<Long> ids);
 
     @Query("select pa from PassArchive pa" +
+            " join fetch pa.member" +
+            " where pa.passArchiveId in :archiveIds")
+    List<PassArchive> findAllByArchiveIdsWithSeller(@Param("archiveIds") List<Long> archiveIds);
+
+    @Query("select pa from PassArchive pa" +
             " join fetch pa.products" +
             " where pa.passArchiveId=:archiveId")
     Optional<PassArchive>findArchiveByArchiveIdWithProducts(@Param("archiveId")Long archiveId);

--- a/src/main/java/com/forwork/backend/api/pay/controller/PayoutController.java
+++ b/src/main/java/com/forwork/backend/api/pay/controller/PayoutController.java
@@ -1,0 +1,81 @@
+package com.forwork.backend.api.pay.controller;
+
+import com.forwork.backend.api.pay.dto.request.PayoutRequestDTO;
+import com.forwork.backend.api.pay.dto.response.TestPayoutResponseDTO;
+import com.forwork.backend.api.pay.enums.PayoutStatus;
+import com.forwork.backend.api.pay.service.PayoutService;
+import com.forwork.backend.common.config.security.SecurityMember;
+import com.forwork.backend.common.dto.PageResponseDTO;
+import com.forwork.backend.common.response.ApiResponse;
+import com.forwork.backend.common.response.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Payout", description = "인출 관련 API 입니다.")
+@RestController
+@RequestMapping("/api/v2/payout")
+@RequiredArgsConstructor
+public class PayoutController {
+    private final PayoutService payoutService;
+
+
+
+    /*
+    * c
+    * */
+
+    @Operation(
+            summary = "인출 요청 API (용범)", description = "입력: PayoutRequestDTO"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인출 요청 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 인출 요청한 결제 내역입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "인출 요청자와 판매자가 일치하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 사용자를 찾을 수 없습니다."),
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> requestPayout(@AuthenticationPrincipal SecurityMember securityMember,
+                                                           @RequestBody PayoutRequestDTO payoutRequestDTO) {
+        payoutService.requestPayout(securityMember.getId(), payoutRequestDTO.paymentIds());
+
+        return ApiResponse.success_only(SuccessStatus.REQUEST_PAYOUT_SUCCESS);
+    }
+
+
+    /*
+    * 테스트
+    * */
+
+    @Operation(
+            summary = "테스트:: 인출 조회 API", description = "출력: TestPayoutResponseDTO"
+    )
+    @ApiResponses({})
+    @GetMapping
+    public ResponseEntity<ApiResponse<PageResponseDTO<TestPayoutResponseDTO>>> getPayouts(
+            @AuthenticationPrincipal SecurityMember securityMember,
+
+            @Parameter(description = "판매자 id", in = ParameterIn.QUERY)
+            @RequestParam(value = "sellerId", required = false) Long sellerId,
+
+            @Parameter(description = "인출 상태", in = ParameterIn.QUERY)
+            @RequestParam(value = "payoutStatus", required = false) PayoutStatus payoutStatus,
+
+
+            @Parameter(description = "페이지 번호 (0부터 시작)", in = ParameterIn.QUERY)
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+
+            @Parameter(description = "페이지 크기", in = ParameterIn.QUERY)
+            @RequestParam(value = "size", defaultValue = "10") Integer size) {
+        PageResponseDTO<TestPayoutResponseDTO> response = payoutService.getPayouts(sellerId, payoutStatus, page, size);
+
+        return ApiResponse.success(SuccessStatus.REQUEST_PAYOUT_SUCCESS, response);
+    }
+
+}

--- a/src/main/java/com/forwork/backend/api/pay/dto/request/PayoutRequestDTO.java
+++ b/src/main/java/com/forwork/backend/api/pay/dto/request/PayoutRequestDTO.java
@@ -1,0 +1,11 @@
+package com.forwork.backend.api.pay.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record PayoutRequestDTO(
+        @Schema(description="인출할 결제 내역 ids")
+        List<Long> paymentIds
+) {
+}

--- a/src/main/java/com/forwork/backend/api/pay/dto/response/TestPayoutResponseDTO.java
+++ b/src/main/java/com/forwork/backend/api/pay/dto/response/TestPayoutResponseDTO.java
@@ -1,0 +1,27 @@
+package com.forwork.backend.api.pay.dto.response;
+
+import com.forwork.backend.api.pay.entity.Payout;
+import com.forwork.backend.api.pay.enums.PayoutStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record TestPayoutResponseDTO(
+        @Schema(description = "payoutId")
+        Long payoutId,
+        @Schema(description = "금액")
+        String totalAmount,
+        @Schema(description = "상태")
+        PayoutStatus payoutStatus,
+        @Schema(description = "판매자 id")
+        Long sellerId
+
+) {
+
+    public static TestPayoutResponseDTO of(Payout payout) {
+        return new TestPayoutResponseDTO(
+                payout.getId(),
+                payout.getTotalAmount(),
+                payout.getPayoutStatus(),
+                payout.getSeller().getId()
+        );
+    }
+}

--- a/src/main/java/com/forwork/backend/api/pay/entity/Payment.java
+++ b/src/main/java/com/forwork/backend/api/pay/entity/Payment.java
@@ -51,6 +51,10 @@ public class Payment extends ExtendedBaseTimeEntity {
     @JoinColumn(name = "order_id")
     private Order order;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name="payout_id")
+    private Payout payout;
+
     public void updatePayment(PaymentDTO paymentDTO){
         paymentStatus =PaymentStatus.fromTossStatus(paymentDTO.tossPaymentStatus());
         totalAmount= paymentDTO.totalAmount();
@@ -66,5 +70,9 @@ public class Payment extends ExtendedBaseTimeEntity {
 
     public void setCreatedDate(LocalDate createdDate) {
         this.createdDate = createdDate;
+    }
+
+    public void requestPayout(Payout payout){
+        this.payout = payout;
     }
 }

--- a/src/main/java/com/forwork/backend/api/pay/entity/Payout.java
+++ b/src/main/java/com/forwork/backend/api/pay/entity/Payout.java
@@ -1,0 +1,28 @@
+package com.forwork.backend.api.pay.entity;
+
+import com.forwork.backend.api.member.entity.Member;
+import com.forwork.backend.api.pay.enums.PayoutStatus;
+import com.forwork.backend.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import static jakarta.persistence.EnumType.STRING;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Payout extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payout_id")
+    private Long id;
+
+    private String totalAmount;
+    @Enumerated(STRING)
+    private PayoutStatus payoutStatus;
+
+    @ManyToOne
+    @JoinColumn(name="seller_id")
+    private Member seller;
+}

--- a/src/main/java/com/forwork/backend/api/pay/enums/PayoutStatus.java
+++ b/src/main/java/com/forwork/backend/api/pay/enums/PayoutStatus.java
@@ -1,0 +1,9 @@
+package com.forwork.backend.api.pay.enums;
+
+public enum PayoutStatus {
+    REQUESTED,      // 인출 요청됨
+    PROCESSING,     // 지급 처리 중
+    COMPLETED,      // 지급 완료
+    FAILED,         // 지급 실패
+    CANCELED        // 요청 취소
+}

--- a/src/main/java/com/forwork/backend/api/pay/repository/PaymentRepository.java
+++ b/src/main/java/com/forwork/backend/api/pay/repository/PaymentRepository.java
@@ -29,6 +29,11 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
             " where p.paymentStatus = :status and p.createdDate <= :beforeDate")
     List<Payment> findPaymentCreatedBefore(@Param("status")PaymentStatus status, @Param("beforeDate") LocalDate beforeDate, Pageable pageable);
 
+    @Query("select distinct payment.id from Payout payout" +
+            " join Payment payment on payment.payout.id=payout.id" +
+            " where payout.seller.id=:sellerId")
+    List<Long> findPaymentIdsBySellerId(@Param("sellerId") Long sellerId);
+
     @Query("select distinct p.id from Payment p" +
             " join p.order o" +
             " join OrderPassArchive opa on opa.order.id=o.id" +

--- a/src/main/java/com/forwork/backend/api/pay/repository/PayoutRepository.java
+++ b/src/main/java/com/forwork/backend/api/pay/repository/PayoutRepository.java
@@ -1,0 +1,7 @@
+package com.forwork.backend.api.pay.repository;
+
+import com.forwork.backend.api.pay.entity.Payout;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PayoutRepository extends JpaRepository<Payout, Long>, PayoutRepositoryQueryDSL{
+}

--- a/src/main/java/com/forwork/backend/api/pay/repository/PayoutRepositoryImpl.java
+++ b/src/main/java/com/forwork/backend/api/pay/repository/PayoutRepositoryImpl.java
@@ -1,0 +1,65 @@
+package com.forwork.backend.api.pay.repository;
+
+import com.forwork.backend.api.pay.entity.Payout;
+import com.forwork.backend.api.pay.enums.PayoutStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.Collections;
+import java.util.List;
+
+import static com.forwork.backend.api.pay.entity.QPayout.payout;
+
+public class PayoutRepositoryImpl implements PayoutRepositoryQueryDSL {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PayoutRepositoryImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<Payout> findBySellerIdAndPayoutStatus(Long sellerId, PayoutStatus payoutStatus, Pageable pageable) {
+        List<Payout> content = queryFactory.selectFrom(payout)
+                .join(payout.seller).fetchJoin()
+                .where(
+                        sellerIdEq(sellerId),
+                        payoutStatusEq(payoutStatus)
+                )
+                .orderBy(payout.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        if(content.isEmpty()){
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(payout.count())
+                .from(payout)
+                .where(
+                        sellerIdEq(sellerId),
+                        payoutStatusEq(payoutStatus)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+
+    }
+
+    private BooleanExpression sellerIdEq(Long sellerId){
+        return (sellerId == null)?null
+                : payout.seller.id.eq(sellerId);
+    }
+
+    private BooleanExpression payoutStatusEq(PayoutStatus payoutStatus){
+        return (payoutStatus == null)?null
+                : payout.payoutStatus.eq(payoutStatus);
+    }
+}

--- a/src/main/java/com/forwork/backend/api/pay/repository/PayoutRepositoryQueryDSL.java
+++ b/src/main/java/com/forwork/backend/api/pay/repository/PayoutRepositoryQueryDSL.java
@@ -1,0 +1,10 @@
+package com.forwork.backend.api.pay.repository;
+
+import com.forwork.backend.api.pay.entity.Payout;
+import com.forwork.backend.api.pay.enums.PayoutStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PayoutRepositoryQueryDSL {
+    Page<Payout> findBySellerIdAndPayoutStatus(Long sellerId, PayoutStatus payoutStatus, Pageable pageable);
+}

--- a/src/main/java/com/forwork/backend/api/pay/service/PayoutService.java
+++ b/src/main/java/com/forwork/backend/api/pay/service/PayoutService.java
@@ -1,0 +1,136 @@
+package com.forwork.backend.api.pay.service;
+
+import com.forwork.backend.api.member.entity.Member;
+import com.forwork.backend.api.member.repository.MemberRepository;
+import com.forwork.backend.api.order.repository.OrderPassArchiveRepository;
+import com.forwork.backend.api.pass_archive.entity.PassArchive;
+import com.forwork.backend.api.pass_archive.repository.PassArchiveRepository;
+import com.forwork.backend.api.pay.dto.response.TestPayoutResponseDTO;
+import com.forwork.backend.api.pay.entity.Payment;
+import com.forwork.backend.api.pay.entity.Payout;
+import com.forwork.backend.api.pay.enums.PayoutStatus;
+import com.forwork.backend.api.pay.repository.PaymentRepository;
+import com.forwork.backend.api.pay.repository.PayoutRepository;
+import com.forwork.backend.common.dto.PageResponseDTO;
+import com.forwork.backend.common.exception.BadRequestException;
+import com.forwork.backend.common.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static com.forwork.backend.common.response.ErrorStatus.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PayoutService {
+    private final PaymentRepository paymentRepository;
+    private final OrderPassArchiveRepository orderPassArchiveRepository;
+    private final PassArchiveRepository passArchiveRepository;
+    private final MemberRepository memberRepository;
+    private final PayoutRepository payoutRepository;
+
+    /*
+    * c
+    * */
+
+    /**
+     * 인출 요청
+     */
+    @Transactional
+    public void requestPayout(Long requesterId, List<Long> paymentIds){
+
+        /*
+        * 해당 payment 가 seller 소유가 맞는지 확인해야 함.
+        * */
+
+        // order 조회
+        List<Payment> payments = paymentRepository.findByPaymentIdsWithOrder(paymentIds);
+        List<Long> orderIds = payments.stream()
+                .map(payment -> payment.getOrder().getId())
+                .toList();
+
+
+        // 아카이브 조회
+        List<Long> archiveIds = orderPassArchiveRepository.findArchiveIdsByOrderIds(orderIds);
+        List<PassArchive> archives = passArchiveRepository.findAllByArchiveIdsWithSeller(archiveIds);
+
+        // 소유자인지 확인
+        archives.forEach(passArchive -> {
+            Member seller = passArchive.getMember();
+
+            if(!seller.getId().equals(requesterId)){
+                log.warn("[requestPayout][다른 사람이 인출 시도][requesterId= {}, sellerId= {}]", requesterId, seller.getId());
+                throw new BadRequestException(UNAUTHORIZED_PAYOUT_REQUEST_EXCEPTION.getMessage());
+            }
+        });
+
+        /*
+        * 이미 인출한 payment 인지
+        * */
+
+        // 이미 인출 요청한 paymentId 조회
+        List<Long> requestedPaymentIds = paymentRepository.findPaymentIdsBySellerId(requesterId);
+
+        // 이번 요청과 겹치는지 체크
+        List<Long> duplicatePayments = paymentIds.stream()
+                .filter(requestedPaymentIds::contains)
+                .toList();
+
+        if (!duplicatePayments.isEmpty()) {
+            log.warn("[requestPayout][이미 요청된 결제 포함][requesterId={}, duplicatePayments={}]", requesterId, duplicatePayments);
+            throw new BadRequestException(PAYOUT_ALREADY_REQUESTED_EXCEPTION.getMessage());
+        }
+
+        /*
+        * 인출 요청
+        * */
+
+        Member seller = memberRepository.findById(requesterId)
+                .orElseThrow(() -> {
+                    log.warn("[requestPayout][멤버 없음.][requesterId={}]", requesterId);
+                    return new NotFoundException(USER_NOT_FOUND_EXCEPTION.getMessage());
+                });
+
+        BigDecimal totalAmount = payments.stream()
+                .map(payment -> new BigDecimal(payment.getTotalAmount()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        Payout payout = Payout.builder()
+                .totalAmount(totalAmount.toString())
+                .payoutStatus(PayoutStatus.REQUESTED)
+                .seller(seller)
+                .build();
+
+        payoutRepository.save(payout);
+
+
+        payments.forEach(payment -> payment.requestPayout(payout));
+    }
+
+    /*
+     * 테스트
+     * */
+
+    /**
+     * payout 조회
+     */
+    public PageResponseDTO<TestPayoutResponseDTO> getPayouts(Long sellerId, PayoutStatus status, Integer page, Integer size) {
+        Pageable pageable= PageRequest.of(page, size);
+
+        Page<Payout> payouts = payoutRepository.findBySellerIdAndPayoutStatus(sellerId, status, pageable);
+        Page<TestPayoutResponseDTO> dtos = payouts.map(TestPayoutResponseDTO::of);
+
+        PageResponseDTO<TestPayoutResponseDTO> response = PageResponseDTO.of(dtos);
+
+        return response;
+    }
+
+}

--- a/src/main/java/com/forwork/backend/common/response/ErrorStatus.java
+++ b/src/main/java/com/forwork/backend/common/response/ErrorStatus.java
@@ -91,6 +91,7 @@ public enum ErrorStatus {
     REVIEW_ALREADY_WRITTEN_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성하셨습니다."),
     ANSWER_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 답변이 등록되어 있습니다."),
     PAYMENT_ALREADY_EXISTS_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 존재하는 결제 정보입니다. 처음부터 다시 진행해주세요."),
+    PAYOUT_ALREADY_REQUESTED_EXCEPTION(HttpStatus.BAD_REQUEST, "이미 인출 요청한 결제 내역입니다."),
 
     /**
      * 401 UNAUTHORIZED
@@ -110,6 +111,8 @@ public enum ErrorStatus {
     RECRUIT_REVIEW_COMMENT_OWNER_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "해당 댓글에 대한 권한이 없습니다."),
     ARCHIVE_PURCHASE_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "해당 아카이브에 대한 구매 내역이 없습니다."),
     UNAUTHORIZED_INQUIRY_ANSWER_EXCEPTION(HttpStatus.FORBIDDEN, "다른 사람 아카이브 문의에는 답변할 수 없습니다."),
+    UNAUTHORIZED_PAYOUT_REQUEST_EXCEPTION(HttpStatus.FORBIDDEN, "인출 요청자와 판매자가 일치하지 않습니다."),
+
 
     /**
      * 404 NOT_FOUND

--- a/src/main/java/com/forwork/backend/common/response/SuccessStatus.java
+++ b/src/main/java/com/forwork/backend/common/response/SuccessStatus.java
@@ -105,6 +105,9 @@ public enum SuccessStatus {
     SEND_PROFILE_INFO_SUCCESS(HttpStatus.OK,"마이페이지 정보 조회 성공"),
     SEND_ACCOUNT_INFO_SUCCESS(HttpStatus.OK,"계좌정보 조회 성공"),
     MODIFY_ACCOUNT_SUCCESS(HttpStatus.OK,"계좌정보 수정 성공"),
+    REQUEST_PAYOUT_SUCCESS(HttpStatus.OK, "인출 요청 성공"),
+
+
 
     /**
      * 201


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #56 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 판매한 아카이브 인출 요청
- 인출 조회

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야할 사항이나 궁금증을 적어주세요 -->
- 현재는 Payout 엔티티에 인출 요청 시 필요한 정보만 반영.
- 인출 조회는 응답 시 어떤 필드가 필요한지는 아직 확정되지 않아 테스트용으로 구현.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 다른 사람 결제 내역 인출 시도
<img width="862" height="372" alt="너 거 아닌데 왜 요청" src="https://github.com/user-attachments/assets/08add8b6-cbfc-4185-ab02-e47aca65faaa" />

- 인출 요청한 결제 내역 다시 인출
<img width="876" height="373" alt="이미 인출 요청한 거 또 요청" src="https://github.com/user-attachments/assets/d6087e59-7583-4971-b91c-ac3622b8b98d" />

- 인출 요청 성공
<img width="886" height="337" alt="인출 요청 성공" src="https://github.com/user-attachments/assets/d5b7c16c-98de-4d74-a47b-e0d7ba92e94c" />

- 인출 조회 성공
<img width="1772" height="627" alt="인출 조회 성공" src="https://github.com/user-attachments/assets/e041af60-4afe-46a6-a674-05b84addf621" />

