### PR TITLE
[FIX] 이력서 로직 수정

### DIFF
--- a/src/main/java/com/forwork/backend/api/resume/controller/ResumeController.java
+++ b/src/main/java/com/forwork/backend/api/resume/controller/ResumeController.java
@@ -36,7 +36,7 @@ public class ResumeController {
 
     @Operation(
             summary = "이력서 초안 생성 API (1페이지) (태근)",
-            description = "이력서 이름(필수), 프로필 이미지(필수), 자기소개(선택), URL 리스트(선택)를 받아 이력서를 생성합니다. " +
+            description = "이력서 이름(필수), 프로필 이미지(필수), 템플릿(필수), 자기소개(선택), URL 리스트(선택)를 받아 이력서를 생성합니다. " +
                     "입력된 필수/선택값은 자동으로 체크됩니다."
     )
     @ApiResponses({

--- a/src/main/java/com/forwork/backend/api/resume/dto/ResumeCreateRequest.java
+++ b/src/main/java/com/forwork/backend/api/resume/dto/ResumeCreateRequest.java
@@ -15,6 +15,9 @@ public class ResumeCreateRequest {
     @NotBlank(message = "이력서 이름은 필수입니다")
     private String resumeName;
 
+    @NotBlank(message = "템플릿은 필수입니다")
+    private String template;
+
     private String introduction;
 
     @Valid

--- a/src/main/java/com/forwork/backend/api/resume/dto/ResumeDetailResponse.java
+++ b/src/main/java/com/forwork/backend/api/resume/dto/ResumeDetailResponse.java
@@ -14,6 +14,7 @@ import java.util.List;
 public class ResumeDetailResponse {
     private Long resumeId;
     private String resumeName;
+    private String template;
     private String profileImageUrl;
     private String introduction;
 
@@ -70,6 +71,7 @@ public class ResumeDetailResponse {
     public static class EducationDto {
         private Long id;
         private String schoolName;
+        private List<String> majors;
         private String admissionDate;
         private String graduationDate;
         private Double earnedScore;

--- a/src/main/java/com/forwork/backend/api/resume/entity/Resume.java
+++ b/src/main/java/com/forwork/backend/api/resume/entity/Resume.java
@@ -30,6 +30,8 @@ public class Resume extends BaseTimeEntity {
     @Column(nullable = false)
     private String resumeName;
 
+    private String template;
+
     private String profileImageUrl;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/forwork/backend/api/resume/service/ResumeService.java
+++ b/src/main/java/com/forwork/backend/api/resume/service/ResumeService.java
@@ -45,6 +45,7 @@ public class ResumeService {
 
     private final MemberSpecificationRepository memberSpecificationRepository;
     private final MemberEducationRepository memberEducationRepository;
+    private final MemberMajorRepository memberMajorRepository;
     private final MemberCertificationRepository memberCertificationRepository;
     private final MemberLanguageSkillRepository memberLanguageSkillRepository;
     private final MemberCareerRepository memberCareerRepository;
@@ -77,6 +78,7 @@ public class ResumeService {
         Resume resume = Resume.builder()
                 .member(member)
                 .resumeName(resumeCreateRequest.getResumeName())
+                .template(resumeCreateRequest.getTemplate())
                 .introduction(resumeCreateRequest.getIntroduction())
                 .profileImageUrl(imageUrl)
                 .includeIntroduction(hasIntroduction)
@@ -205,6 +207,7 @@ public class ResumeService {
             if (resume.isIncludeEducation()) {
                 educations = memberEducationRepository.findAllByMemberSpecificationId(specId).stream()
                         .map(edu -> ResumeDetailResponse.EducationDto.builder()
+                                .majors(memberMajorRepository.findAllByMemberEducationId(edu.getId()))
                                 .id(edu.getId())
                                 .schoolName(edu.getSchoolName())
                                 .admissionDate(edu.getAdmissionDate())
@@ -286,6 +289,7 @@ public class ResumeService {
         return ResumeDetailResponse.builder()
                 .resumeId(resume.getId())
                 .resumeName(resume.getResumeName())
+                .template(resume.getTemplate())
                 .profileImageUrl(resume.getProfileImageUrl())
                 .introduction(resume.isIncludeIntroduction() ? resume.getIntroduction() : null)
                 .memberBasicInfo(memberBasicInfo)
@@ -330,4 +334,3 @@ public class ResumeService {
         resumeRepository.delete(resume);
     }
 }
-


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #133

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->

- 이력서 2차 데이터 저장시 템플릿을 저장할 수 있게 수정하였습니다.
- 이력서 상세 조회 시 저장한 템플릿 유형을 반환하는 필드를 추가하였습니다.
- 이력서 상세 조회 시 educations 필드에 Major가 반환되도록 수정하였습니다.